### PR TITLE
Fix Kotlin Compose plugin error by upgrading to Kotlin 2.0.21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.application") version "8.2.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.20" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "1.9.20" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
 }


### PR DESCRIPTION
The org.jetbrains.kotlin.plugin.compose plugin was not available for Kotlin 1.9.20 as it was introduced in Kotlin 2.0.0. This upgrade resolves the plugin resolution error.

Changes:
- Upgrade Kotlin from 1.9.20 to 2.0.21
- Kotlin Compose plugin now properly supported

Fixes the build error: Plugin 'org.jetbrains.kotlin.plugin.compose' version '1.9.20' was not found