### PR TITLE
Add launcher icon resources for Retro Tetris app

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M0,0h108v108h-108z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <!-- Tetris T-piece in retro cyan color -->
+    <group
+        android:translateX="54"
+        android:translateY="54">
+        <!-- Top horizontal blocks -->
+        <path
+            android:fillColor="#00F0F0"
+            android:pathData="M-15,-15h10v10h-10z"/>
+        <path
+            android:fillColor="#00F0F0"
+            android:pathData="M-5,-15h10v10h-10z"/>
+        <path
+            android:fillColor="#00F0F0"
+            android:pathData="M5,-15h10v10h-10z"/>
+        <!-- Bottom center block -->
+        <path
+            android:fillColor="#00F0F0"
+            android:pathData="M-5,-5h10v10h-10z"/>
+
+        <!-- Block borders (darker) -->
+        <path
+            android:fillColor="#00A0A0"
+            android:pathData="M-15,-15h10v1h-10z"/>
+        <path
+            android:fillColor="#00A0A0"
+            android:pathData="M-15,-15h1v10h-1z"/>
+        <path
+            android:fillColor="#00A0A0"
+            android:pathData="M-5,-15h10v1h-10z"/>
+        <path
+            android:fillColor="#00A0A0"
+            android:pathData="M-5,-15h1v10h-1z"/>
+        <path
+            android:fillColor="#00A0A0"
+            android:pathData="M5,-15h10v1h-10z"/>
+        <path
+            android:fillColor="#00A0A0"
+            android:pathData="M5,-15h1v10h-1z"/>
+        <path
+            android:fillColor="#00A0A0"
+            android:pathData="M-5,-5h10v1h-10z"/>
+        <path
+            android:fillColor="#00A0A0"
+            android:pathData="M-5,-5h1v10h-1z"/>
+    </group>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background"/>
+    <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background"/>
+    <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+</adaptive-icon>

--- a/app/src/main/res/mipmap-hdpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-hdpi/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_background"/>
+    <item android:drawable="@drawable/ic_launcher_foreground"/>
+</layer-list>

--- a/app/src/main/res/mipmap-hdpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-hdpi/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_background"/>
+    <item android:drawable="@drawable/ic_launcher_foreground"/>
+</layer-list>

--- a/app/src/main/res/mipmap-mdpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-mdpi/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_background"/>
+    <item android:drawable="@drawable/ic_launcher_foreground"/>
+</layer-list>

--- a/app/src/main/res/mipmap-mdpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-mdpi/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_background"/>
+    <item android:drawable="@drawable/ic_launcher_foreground"/>
+</layer-list>

--- a/app/src/main/res/mipmap-xhdpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-xhdpi/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_background"/>
+    <item android:drawable="@drawable/ic_launcher_foreground"/>
+</layer-list>

--- a/app/src/main/res/mipmap-xhdpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-xhdpi/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_background"/>
+    <item android:drawable="@drawable/ic_launcher_foreground"/>
+</layer-list>

--- a/app/src/main/res/mipmap-xxhdpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-xxhdpi/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_background"/>
+    <item android:drawable="@drawable/ic_launcher_foreground"/>
+</layer-list>

--- a/app/src/main/res/mipmap-xxhdpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-xxhdpi/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_background"/>
+    <item android:drawable="@drawable/ic_launcher_foreground"/>
+</layer-list>

--- a/app/src/main/res/mipmap-xxxhdpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-xxxhdpi/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_background"/>
+    <item android:drawable="@drawable/ic_launcher_foreground"/>
+</layer-list>

--- a/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_launcher_background"/>
+    <item android:drawable="@drawable/ic_launcher_foreground"/>
+</layer-list>


### PR DESCRIPTION
Created adaptive launcher icons with Tetris-themed design featuring a cyan T-piece block on black background, maintaining the retro aesthetic.

Changes:
- Add adaptive icon XMLs for Android 8.0+ (anydpi-v26)
- Add background and foreground vector drawables
- Add launcher icon resources for all density buckets (mdpi, hdpi, xhdpi, xxhdpi, xxxhdpi)
- Use layer-list for legacy Android version compatibility

Fixes AAPT error: resource mipmap/ic_launcher not found