### PR TITLE
Configure release build with signing config

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,9 +20,21 @@ android {
         }
     }
 
+    signingConfigs {
+        create("release") {
+            // For development/testing purposes, using debug keystore
+            // For production, replace with your own keystore
+            storeFile = file(System.getProperty("user.home") + "/.android/debug.keystore")
+            storePassword = "android"
+            keyAlias = "androiddebugkey"
+            keyPassword = "android"
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = true
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"


### PR DESCRIPTION
Added signing configuration for release builds using the debug keystore for development/testing purposes. This allows building release APKs without requiring a production keystore setup.

Changes:
- Add signingConfigs block with release configuration
- Use Android debug keystore for signing
- Enable release signing in buildTypes

Note: For production releases, replace with a proper production keystore.