### PR TITLE
Fix build error: Remove Options screen from MainActivity

### DIFF
--- a/app/src/main/java/com/tetris/GameViewModel.kt
+++ b/app/src/main/java/com/tetris/GameViewModel.kt
@@ -154,23 +154,6 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         _screenState.value = ScreenState.Menu
     }
 
-    /**
-     * Show options screen
-     */
-    fun showOptions() {
-        _screenState.value = ScreenState.Options
-    }
-
-    /**
-     * Change theme
-     */
-    fun changeTheme(theme: TetrisTheme) {
-        _currentTheme.value = theme
-        viewModelScope.launch {
-            preferences.saveTheme(theme.name)
-        }
-    }
-
     override fun onCleared() {
         super.onCleared()
         game?.dispose()
@@ -183,5 +166,4 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
 sealed class ScreenState {
     object Menu : ScreenState()
     object Game : ScreenState()
-    object Options : ScreenState()
 }

--- a/app/src/main/java/com/tetris/MainActivity.kt
+++ b/app/src/main/java/com/tetris/MainActivity.kt
@@ -10,8 +10,6 @@ import androidx.compose.ui.Modifier
 import com.tetris.game.GameState
 import com.tetris.ui.GameScreen
 import com.tetris.ui.MenuScreen
-import com.tetris.ui.OptionsScreen
-import com.tetris.ui.theme.AllThemes
 
 /**
  * Main activity for the Tetris game
@@ -41,17 +39,6 @@ fun TetrisApp(viewModel: GameViewModel) {
                 theme = currentTheme,
                 highScore = highScore,
                 onStartGame = { viewModel.startGame() },
-                onOptions = { viewModel.showOptions() },
-                modifier = Modifier.fillMaxSize()
-            )
-        }
-
-        is ScreenState.Options -> {
-            OptionsScreen(
-                currentTheme = currentTheme,
-                availableThemes = AllThemes,
-                onThemeSelected = { viewModel.changeTheme(it) },
-                onBack = { viewModel.returnToMenu() },
                 modifier = Modifier.fillMaxSize()
             )
         }


### PR DESCRIPTION
- Remove onOptions parameter from MenuScreen call in MainActivity
- Remove OptionsScreen import from MainActivity
- Remove ScreenState.Options from GameViewModel
- Remove showOptions() and changeTheme() functions (no longer needed)
- Simplify to single theme mode (MinimalisticTheme as default)

This fixes the build error: "No parameter with name 'onOptions' found"