### PR TITLE
Make board frame 10px wider on all sides with overlay effect

### DIFF
--- a/app/src/main/java/com/tetris/ui/components/GameBoard.kt
+++ b/app/src/main/java/com/tetris/ui/components/GameBoard.kt
@@ -83,25 +83,31 @@ fun GameBoard(
             calculatedWidth to maxHeight
         }
 
+        // Frame border width: 10dp on each side (20dp total width/height added)
+        val frameBorderSize = 10.dp
+        val frameBorderPx = frameBorderSize.value * density
+
+        // Adjust canvas size to include frame border
+        val canvasWidth = finalWidth + (frameBorderSize * 2)
+        val canvasHeight = finalHeight + (frameBorderSize * 2)
+
         Canvas(
             modifier = Modifier
-                .size(width = finalWidth, height = finalHeight)
+                .size(width = canvasWidth, height = canvasHeight)
                 .let {
                     if (boardFrameDrawable == null) it.border(3.dp, theme.gridBorder)
                     else it
                 }
         ) {
-            val blockSizePx = size.width / boardWidth
+            // Calculate block size based on inner area (without frame)
+            val innerWidth = size.width - (frameBorderPx * 2)
+            val blockSizePx = innerWidth / boardWidth
 
-            // Draw board frame if available
-            boardFrameDrawable?.let { drawable ->
-                drawable.setBounds(0, 0, size.width.toInt(), size.height.toInt())
-                drawContext.canvas.nativeCanvas.apply {
-                    drawable.draw(this)
-                }
-            }
+            // Offset for drawing blocks (frame border)
+            val offsetX = frameBorderPx
+            val offsetY = frameBorderPx
 
-            // Draw locked blocks
+            // Draw locked blocks (with offset for frame border)
             board.forEachIndexed { y, row ->
                 row.forEachIndexed { x, color ->
                     if (color != null) {
@@ -113,21 +119,21 @@ fun GameBoard(
                             drawBlockFromSpritesheet(
                                 spritesheet = blocksSpritesheet,
                                 tetrominoType = tetrominoType,
-                                x = x * blockSizePx,
-                                y = y * blockSizePx,
+                                x = x * blockSizePx + offsetX,
+                                y = y * blockSizePx + offsetY,
                                 size = blockSizePx
                             )
                         } else {
                             // Fallback to colored rectangles
                             drawRect(
                                 color = color,
-                                topLeft = Offset(x * blockSizePx, y * blockSizePx),
+                                topLeft = Offset(x * blockSizePx + offsetX, y * blockSizePx + offsetY),
                                 size = Size(blockSizePx - 2, blockSizePx - 2)
                             )
                             // Border
                             drawRect(
                                 color = theme.blockBorder,
-                                topLeft = Offset(x * blockSizePx, y * blockSizePx),
+                                topLeft = Offset(x * blockSizePx + offsetX, y * blockSizePx + offsetY),
                                 size = Size(blockSizePx - 2, blockSizePx - 2),
                                 style = androidx.compose.ui.graphics.drawscope.Stroke(width = 2f)
                             )
@@ -149,21 +155,21 @@ fun GameBoard(
                                     drawBlockFromSpritesheet(
                                         spritesheet = blocksSpritesheet,
                                         tetrominoType = piece.type,
-                                        x = x * blockSizePx,
-                                        y = y * blockSizePx,
+                                        x = x * blockSizePx + offsetX,
+                                        y = y * blockSizePx + offsetY,
                                         size = blockSizePx
                                     )
                                 } else {
                                     // Fallback to colored rectangles
                                     drawRect(
                                         color = piece.color,
-                                        topLeft = Offset(x * blockSizePx, y * blockSizePx),
+                                        topLeft = Offset(x * blockSizePx + offsetX, y * blockSizePx + offsetY),
                                         size = Size(blockSizePx - 2, blockSizePx - 2)
                                     )
                                     // Border
                                     drawRect(
                                         color = theme.blockBorder,
-                                        topLeft = Offset(x * blockSizePx, y * blockSizePx),
+                                        topLeft = Offset(x * blockSizePx + offsetX, y * blockSizePx + offsetY),
                                         size = Size(blockSizePx - 2, blockSizePx - 2),
                                         style = androidx.compose.ui.graphics.drawscope.Stroke(width = 2f)
                                     )
@@ -171,6 +177,14 @@ fun GameBoard(
                             }
                         }
                     }
+                }
+            }
+
+            // Draw board frame as overlay (after blocks for overlay effect)
+            boardFrameDrawable?.let { drawable ->
+                drawable.setBounds(0, 0, size.width.toInt(), size.height.toInt())
+                drawContext.canvas.nativeCanvas.apply {
+                    drawable.draw(this)
                 }
             }
         }

--- a/app/src/main/res/drawable/board_frame.xml
+++ b/app/src/main/res/drawable/board_frame.xml
@@ -3,20 +3,27 @@
     PLATZHALTER: Ersetzen Sie diese Datei durch board_frame.png
 
     Dies ist der Rahmen für das Spielfeld (10x20 Blöcke).
+    Der Rahmen wird als OVERLAY über die Blöcke gezeichnet.
 
     Spezifikationen:
-    - Größe: Sollte das Spielfeld umrahmen (Empfehlung: 640 x 1280 px + Rahmendicke)
-    - Format: PNG (empfohlen - unterstützt Transparenz), WebP oder JPG
-    - Der innere transparente Bereich sollte exakt das Spielfeld-Verhältnis haben (10:20)
-    - Der Rahmen wird über das Spielfeld gelegt
+    - Rahmenbreite: 10px auf allen Seiten (links, rechts, oben, unten)
+    - Gesamtgröße: Spielfeld-Größe + 20px Breite + 20px Höhe
+    - Beispiel: Spielfeld 640x1280 px → Rahmen 660x1300 px
+    - Format: PNG (empfohlen - MUSS Transparenz unterstützen), WebP
+
+    Aufbau:
+    - Äußere 10px: Rahmen-Grafik (sichtbar)
+    - Innerer Bereich: TRANSPARENT (damit Blöcke durchscheinen)
+    - Der Rahmen überlappt die äußeren Blöcke um 10px
 
     Design-Tipps:
-    - Kann dekorativ sein (z.B. 3D-Effekt, Neon-Glow, Holz-Textur, etc.)
-    - Sollte nicht zu dick sein (max 20-30px pro Seite empfohlen)
-    - Innerer Bereich muss transparent sein, damit die Blöcke sichtbar bleiben
+    - Der Rahmen kann dekorativ sein (3D-Effekt, Schatten, Glow, Textur, etc.)
+    - Innerer transparenter Bereich ist WICHTIG
+    - Der Rahmen liegt ÜBER den Blöcken (Overlay-Effekt)
+    - Empfehlung: Dickerer Rahmen für bessere Sichtbarkeit (10-15px)
 
     Diese XML-Datei ist nur ein einfacher Platzhalter-Rahmen.
-    Ersetzen Sie sie durch Ihre eigene PNG-Datei für bessere Grafik.
+    Ersetzen Sie sie durch Ihre eigene PNG-Datei mit Transparenz.
 -->
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">


### PR DESCRIPTION
Changes to GameBoard.kt:
- Canvas size increased by 20dp total (10dp on each side)
- All block positions offset by 10dp from each edge
- Frame rendered AFTER blocks (overlay effect on top)
- Frame now overlaps outer blocks by 10px on each side

Changes to board_frame.xml:
- Updated documentation for new frame specifications
- Frame size: Game board + 20px width + 20px height
- Example: 640x1280 board → 660x1300 frame
- Inner area MUST be transparent for blocks to show through
- Frame drawn as overlay over blocks

Result:
- Thicker, more visible frame graphics possible
- Frame can have 3D effects, shadows, glows
- Outer blocks are partially covered by frame (overlay effect)