### PR TITLE
Revert to uniform 10dp frame border on all sides

### DIFF
--- a/app/src/main/java/com/tetris/ui/components/GameBoard.kt
+++ b/app/src/main/java/com/tetris/ui/components/GameBoard.kt
@@ -86,14 +86,12 @@ fun GameBoard(
             calculatedWidth to maxHeight
         }
 
-        // Frame border width: 10dp on top/left/right, 30dp on bottom (20dp extra)
-        val frameBorderSizeTop = 10.dp
-        val frameBorderSideSize = 10.dp
-        val frameBorderSizeBottom = 30.dp
+        // Frame border width: 10dp on each side
+        val frameBorderSize = 10.dp
 
         // Adjust canvas size to include frame border
-        val canvasWidth = finalWidth + (frameBorderSideSize * 2)
-        val canvasHeight = finalHeight + frameBorderSizeTop + frameBorderSizeBottom
+        val canvasWidth = finalWidth + (frameBorderSize * 2)
+        val canvasHeight = finalHeight + (frameBorderSize * 2)
 
         Canvas(
             modifier = Modifier
@@ -104,17 +102,15 @@ fun GameBoard(
                 }
         ) {
             // Convert frame border to pixels
-            val frameBorderTopPx = with(density) { frameBorderSizeTop.toPx() }
-            val frameBorderSidePx = with(density) { frameBorderSideSize.toPx() }
-            val frameBorderBottomPx = with(density) { frameBorderSizeBottom.toPx() }
+            val frameBorderPx = with(density) { frameBorderSize.toPx() }
 
             // Calculate block size based on inner area (without frame)
-            val innerWidth = size.width - (frameBorderSidePx * 2)
+            val innerWidth = size.width - (frameBorderPx * 2)
             val blockSizePx = innerWidth / boardWidth
 
             // Offset for drawing blocks (frame border)
-            val offsetX = frameBorderSidePx
-            val offsetY = frameBorderTopPx
+            val offsetX = frameBorderPx
+            val offsetY = frameBorderPx
 
             // Draw locked blocks (with offset for frame border)
             board.forEachIndexed { y, row ->


### PR DESCRIPTION
- Changed back to 10dp border on all sides (top, bottom, left, right)
- Frame graphic now properly aligned with game board
- Extra bottom space should be part of board_frame.png graphic itself