### PR TITLE
Extend board frame bottom border by 20dp

### DIFF
--- a/app/src/main/java/com/tetris/ui/components/GameBoard.kt
+++ b/app/src/main/java/com/tetris/ui/components/GameBoard.kt
@@ -86,12 +86,14 @@ fun GameBoard(
             calculatedWidth to maxHeight
         }
 
-        // Frame border width: 10dp on each side
-        val frameBorderSize = 10.dp
+        // Frame border width: 10dp on top/left/right, 30dp on bottom
+        val frameBorderTop = 10.dp
+        val frameBorderSide = 10.dp
+        val frameBorderBottom = 30.dp
 
         // Adjust canvas size to include frame border
-        val canvasWidth = finalWidth + (frameBorderSize * 2)
-        val canvasHeight = finalHeight + (frameBorderSize * 2)
+        val canvasWidth = finalWidth + (frameBorderSide * 2)
+        val canvasHeight = finalHeight + frameBorderTop + frameBorderBottom
 
         Canvas(
             modifier = Modifier
@@ -102,15 +104,16 @@ fun GameBoard(
                 }
         ) {
             // Convert frame border to pixels
-            val frameBorderPx = with(density) { frameBorderSize.toPx() }
+            val frameBorderSidePx = with(density) { frameBorderSide.toPx() }
+            val frameBorderTopPx = with(density) { frameBorderTop.toPx() }
 
             // Calculate block size based on inner area (without frame)
-            val innerWidth = size.width - (frameBorderPx * 2)
+            val innerWidth = size.width - (frameBorderSidePx * 2)
             val blockSizePx = innerWidth / boardWidth
 
-            // Offset for drawing blocks (frame border)
-            val offsetX = frameBorderPx
-            val offsetY = frameBorderPx
+            // Offset for drawing blocks (frame stays at top)
+            val offsetX = frameBorderSidePx
+            val offsetY = frameBorderTopPx
 
             // Draw locked blocks (with offset for frame border)
             board.forEachIndexed { y, row ->


### PR DESCRIPTION
- Bottom frame border: 30dp (20dp extra space)
- Top/Left/Right borders: 10dp (unchanged)
- Game board stays at same position (10dp from top)
- Frame graphic extends 20dp below the game board
- Allows board_frame.png to have decorative bottom extension