### PR TITLE
Revert to uniform 10dp frame border on all sides

### DIFF
--- a/app/src/main/java/com/tetris/ui/components/GameBoard.kt
+++ b/app/src/main/java/com/tetris/ui/components/GameBoard.kt
@@ -86,14 +86,12 @@ fun GameBoard(
             calculatedWidth to maxHeight
         }
 
-        // Frame border width: 10dp on top/left/right, 30dp on bottom
-        val frameBorderTop = 10.dp
-        val frameBorderSide = 10.dp
-        val frameBorderBottom = 30.dp
+        // Frame border width: 10dp on all sides
+        val frameBorderSize = 10.dp
 
         // Adjust canvas size to include frame border
-        val canvasWidth = finalWidth + (frameBorderSide * 2)
-        val canvasHeight = finalHeight + frameBorderTop + frameBorderBottom
+        val canvasWidth = finalWidth + (frameBorderSize * 2)
+        val canvasHeight = finalHeight + (frameBorderSize * 2)
 
         Canvas(
             modifier = Modifier
@@ -104,16 +102,15 @@ fun GameBoard(
                 }
         ) {
             // Convert frame border to pixels
-            val frameBorderSidePx = with(density) { frameBorderSide.toPx() }
-            val frameBorderTopPx = with(density) { frameBorderTop.toPx() }
+            val frameBorderPx = with(density) { frameBorderSize.toPx() }
 
             // Calculate block size based on inner area (without frame)
-            val innerWidth = size.width - (frameBorderSidePx * 2)
+            val innerWidth = size.width - (frameBorderPx * 2)
             val blockSizePx = innerWidth / boardWidth
 
-            // Offset for drawing blocks (frame stays at top)
-            val offsetX = frameBorderSidePx
-            val offsetY = frameBorderTopPx
+            // Offset for drawing blocks (frame border)
+            val offsetX = frameBorderPx
+            val offsetY = frameBorderPx
 
             // Draw locked blocks (with offset for frame border)
             board.forEachIndexed { y, row ->


### PR DESCRIPTION
- All sides now have 10dp border (top, bottom, left, right)
- Frame graphic scales to exact canvas size automatically
- Required board_frame.png aspect ratio: 6:11 (or 12:22)
- Example sizes: 600x1100px, 720x1320px, 960x1760px