### PR TITLE
Add graphics support for all menu and UI buttons

### DIFF
--- a/app/src/main/java/com/tetris/ui/GameScreen.kt
+++ b/app/src/main/java/com/tetris/ui/GameScreen.kt
@@ -94,7 +94,8 @@ fun GameScreen(
                 PausedOverlay(
                     theme = theme,
                     onResume = onResume,
-                    onBackToMenu = onBackToMenu
+                    onBackToMenu = onBackToMenu,
+                    useGraphics = useGraphics
                 )
             }
             is GameState.GameOver -> {
@@ -104,7 +105,8 @@ fun GameScreen(
                     lines = gameState.lines,
                     highScore = highScore,
                     theme = theme,
-                    onBackToMenu = onBackToMenu
+                    onBackToMenu = onBackToMenu,
+                    useGraphics = useGraphics
                 )
             }
             else -> {}
@@ -248,8 +250,24 @@ private fun PlayingScreen(
 private fun PausedOverlay(
     theme: TetrisTheme,
     onResume: () -> Unit,
-    onBackToMenu: () -> Unit
+    onBackToMenu: () -> Unit,
+    useGraphics: Boolean = true
 ) {
+    val context = LocalContext.current
+
+    // Load button graphics
+    val buttonResumeResourceId = try {
+        context.resources.getIdentifier("button_resume", "drawable", context.packageName)
+    } catch (e: Exception) {
+        0
+    }
+
+    val buttonMenuResourceId = try {
+        context.resources.getIdentifier("button_menu", "drawable", context.packageName)
+    } catch (e: Exception) {
+        0
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -267,37 +285,73 @@ private fun PausedOverlay(
                 color = theme.textHighlight
             )
 
-            Button(
-                onClick = onResume,
-                modifier = Modifier
-                    .width(200.dp)
-                    .height(56.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = theme.textHighlight,
-                    contentColor = theme.background
-                )
-            ) {
-                Text(
-                    text = "RESUME",
-                    fontSize = 20.sp,
-                    fontWeight = FontWeight.Bold
-                )
+            // Resume button
+            if (useGraphics && buttonResumeResourceId != 0) {
+                Box(
+                    modifier = Modifier
+                        .width(200.dp)
+                        .height(56.dp)
+                        .clickable(onClick = onResume),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Image(
+                        painter = painterResource(id = buttonResumeResourceId),
+                        contentDescription = "Resume",
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Fit
+                    )
+                }
+            } else {
+                Button(
+                    onClick = onResume,
+                    modifier = Modifier
+                        .width(200.dp)
+                        .height(56.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = theme.textHighlight,
+                        contentColor = theme.background
+                    )
+                ) {
+                    Text(
+                        text = "RESUME",
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
             }
 
-            Button(
-                onClick = onBackToMenu,
-                modifier = Modifier
-                    .width(200.dp)
-                    .height(56.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = theme.gridBorder,
-                    contentColor = theme.textPrimary
-                )
-            ) {
-                Text(
-                    text = "MENU",
-                    fontSize = 20.sp
-                )
+            // Menu button
+            if (useGraphics && buttonMenuResourceId != 0) {
+                Box(
+                    modifier = Modifier
+                        .width(200.dp)
+                        .height(56.dp)
+                        .clickable(onClick = onBackToMenu),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Image(
+                        painter = painterResource(id = buttonMenuResourceId),
+                        contentDescription = "Menu",
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Fit
+                    )
+                }
+            } else {
+                Button(
+                    onClick = onBackToMenu,
+                    modifier = Modifier
+                        .width(200.dp)
+                        .height(56.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = theme.gridBorder,
+                        contentColor = theme.textPrimary
+                    )
+                ) {
+                    Text(
+                        text = "MENU",
+                        fontSize = 20.sp
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/tetris/ui/MenuScreen.kt
+++ b/app/src/main/java/com/tetris/ui/MenuScreen.kt
@@ -189,22 +189,61 @@ private fun MenuButton(
     onClick: () -> Unit,
     theme: TetrisTheme,
     highlighted: Boolean = false,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    useGraphics: Boolean = true
 ) {
-    Button(
-        onClick = onClick,
-        modifier = modifier
-            .fillMaxWidth()
-            .height(56.dp),
-        colors = ButtonDefaults.buttonColors(
-            containerColor = if (highlighted) theme.textHighlight else theme.gridBorder,
-            contentColor = if (highlighted) theme.background else theme.textPrimary
-        )
-    ) {
-        Text(
-            text = text,
-            fontSize = 20.sp,
-            fontWeight = FontWeight.Bold
-        )
+    val context = LocalContext.current
+
+    // Load button graphic based on text
+    val buttonType = when (text) {
+        "START GAME" -> "button_start_game"
+        "BACK" -> "button_back"
+        else -> null
+    }
+
+    val buttonResourceId = if (useGraphics && buttonType != null) {
+        try {
+            context.resources.getIdentifier(buttonType, "drawable", context.packageName)
+        } catch (e: Exception) {
+            0
+        }
+    } else {
+        0
+    }
+
+    if (useGraphics && buttonResourceId != 0) {
+        // Use custom graphics
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(56.dp)
+                .clickable(onClick = onClick),
+            contentAlignment = Alignment.Center
+        ) {
+            Image(
+                painter = painterResource(id = buttonResourceId),
+                contentDescription = text,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Fit
+            )
+        }
+    } else {
+        // Fallback to Material3 button
+        Button(
+            onClick = onClick,
+            modifier = modifier
+                .fillMaxWidth()
+                .height(56.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = if (highlighted) theme.textHighlight else theme.gridBorder,
+                contentColor = if (highlighted) theme.background else theme.textPrimary
+            )
+        ) {
+            Text(
+                text = text,
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold
+            )
+        }
     }
 }


### PR DESCRIPTION
Menu Screen:
- button_start_game.png for START GAME button
- button_back.png for BACK button

Pause Screen:
- button_resume.png for RESUME button
- button_menu.png for MENU button

Game Over Screen:
- button_back_to_menu.png for BACK TO MENU button (already added)

All buttons fallback to Material3 UI if graphics not found.