### PR TITLE
Fix type mismatch in addGarbageLines function

### DIFF
--- a/app/src/main/java/com/tetris/game/Board.kt
+++ b/app/src/main/java/com/tetris/game/Board.kt
@@ -150,7 +150,7 @@ class Board(
 
         // Add garbage lines at bottom with one random gap per line
         repeat(count) {
-            val garbageLine = MutableList(width) { garbageColor }
+            val garbageLine = MutableList<Color?>(width) { garbageColor }
             // Add a random gap in each garbage line
             val gapPosition = (0 until width).random()
             garbageLine[gapPosition] = null


### PR DESCRIPTION
Changed garbageLine type from MutableList<Color> to MutableList<Color?> to allow null values for gaps in garbage lines.