### PR TITLE
Add missing MutableStateFlow import to LobbyScreen

### DIFF
--- a/app/src/main/java/com/tetris/ui/LobbyScreen.kt
+++ b/app/src/main/java/com/tetris/ui/LobbyScreen.kt
@@ -26,6 +26,7 @@ import com.tetris.network.ConnectionState
 import com.tetris.network.NetworkManager
 import com.tetris.network.PlayerInfo
 import com.tetris.ui.theme.TetrisTheme
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 


### PR DESCRIPTION
Fixes compilation error: Unresolved reference 'MutableStateFlow' in LobbyScreen.kt lines 41 and 44.