### PR TITLE
Add runtime permission handling and cleartext traffic support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
         android:label="Retro Tetris"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Tetris">
+        android:theme="@style/Theme.Tetris"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
Fixes:
1. Runtime permission handling for Android 13+ (API 33+)
   - Added permission check in ModeSelectionScreen
   - Request NEARBY_WIFI_DEVICES permission before Host/Join
   - Execute pending action automatically after permission granted
   - Graceful fallback for older Android versions

2. Cleartext traffic support
   - Added android:usesCleartextTraffic="true" to application tag
   - Allows local TCP connections without HTTPS

3. Improved imports
   - Added Manifest, PackageManager, Build imports
   - Added ActivityResultContracts for permission launcher
   - Added ContextCompat for permission checking

This fixes crashes when clicking Host Game or Join Game buttons by ensuring required permissions are granted before NSD operations.