### PR TITLE
Fix sealed class compilation error

### DIFF
--- a/app/src/main/java/com/tetris/ui/LobbyScreen.kt
+++ b/app/src/main/java/com/tetris/ui/LobbyScreen.kt
@@ -96,6 +96,16 @@ class LobbyViewModel(application: Application) : AndroidViewModel(application) {
 }
 
 /**
+ * UI state for the Lobby screen
+ */
+private sealed class LobbyUIState {
+    object NameInput : LobbyUIState()
+    object ModeSelection : LobbyUIState()
+    object Hosting : LobbyUIState()
+    object Joining : LobbyUIState()
+}
+
+/**
  * Lobby screen for multiplayer matchmaking
  */
 @Composable
@@ -119,14 +129,6 @@ fun LobbyScreen(
     val discoveredPlayers by viewModel.discoveredPlayers.collectAsState()
     val connectionState by viewModel.connectionState.collectAsState()
     val isHost by viewModel.isHost.collectAsState()
-
-    // UI state management
-    sealed class LobbyUIState {
-        object NameInput : LobbyUIState()
-        object ModeSelection : LobbyUIState()
-        object Hosting : LobbyUIState()
-        object Joining : LobbyUIState()
-    }
 
     var uiState by remember { mutableStateOf<LobbyUIState>(LobbyUIState.NameInput) }
 


### PR DESCRIPTION
Move LobbyUIState sealed class from inside LobbyScreen composable to top-level private declaration. Sealed classes cannot be local or defined within functions.