### PR TITLE
Fix CircularProgressIndicator crash by updating Compose BOM

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,8 +64,8 @@ android {
 }
 
 dependencies {
-    // Compose BOM
-    val composeBom = platform("androidx.compose:compose-bom:2024.01.00")
+    // Compose BOM - Updated to fix CircularProgressIndicator animation incompatibility
+    val composeBom = platform("androidx.compose:compose-bom:2024.10.00")
     implementation(composeBom)
 
     // Core Android


### PR DESCRIPTION
Problem: NoSuchMethodError in CircularProgressIndicator animation Cause: Compose BOM 2024.01.00 had incompatible versions between
       Material3 and Animation Core libraries

Solution: Updated BOM to 2024.10.00 which includes compatible versions

Error was:
java.lang.NoSuchMethodError: No virtual method at(...) in androidx.compose.animation.core.KeyframesSpec$KeyframesSpecConfig at androidx.compose.material3.ProgressIndicatorKt.CircularProgressIndicator at com.tetris.ui.LobbyScreenKt.HostingScreen(LobbyScreen.kt:444)