### PR TITLE
Add comprehensive network diagnostics and debugging for NSD

### DIFF
--- a/app/src/main/java/com/tetris/network/NetworkManager.kt
+++ b/app/src/main/java/com/tetris/network/NetworkManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.wifi.WifiManager
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
+import android.os.Build
 import android.util.Log
 import io.ktor.network.selector.*
 import io.ktor.network.sockets.*
@@ -72,6 +73,11 @@ class NetworkManager(private val context: Context) {
      */
     suspend fun startHosting(playerName: String): Result<Unit> = withContext(Dispatchers.IO) {
         try {
+            Log.d(tag, "=== Starting Host Mode ===")
+
+            // Check WiFi connectivity
+            checkWiFiConnectivity()
+
             // Acquire multicast lock for NSD to work properly
             acquireMulticastLock()
 
@@ -83,7 +89,8 @@ class NetworkManager(private val context: Context) {
             // Start server socket
             serverSocket = aSocket(selectorManager!!).tcp().bind(port = port)
 
-            Log.d(tag, "Server socket bound to port $port")
+            Log.d(tag, "✓ Server socket bound to port $port")
+            Log.d(tag, "✓ Local address: ${serverSocket?.localAddress}")
 
             // Register NSD service
             registerService(playerName)
@@ -122,8 +129,11 @@ class NetworkManager(private val context: Context) {
      * Start discovering available games
      */
     fun startDiscovery() {
-        Log.d(tag, "=== startDiscovery() called ===")
+        Log.d(tag, "=== Starting Discovery Mode ===")
         Log.d(tag, "Service type to discover: $serviceType")
+
+        // Check WiFi connectivity
+        checkWiFiConnectivity()
 
         // Acquire multicast lock for NSD to work properly
         acquireMulticastLock()
@@ -427,8 +437,16 @@ class NetworkManager(private val context: Context) {
 
         val registrationListener = object : NsdManager.RegistrationListener {
             override fun onRegistrationFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
-                Log.e(tag, "✗ Service registration FAILED: errorCode=$errorCode")
-                Log.e(tag, "Failed service name: ${serviceInfo.serviceName}")
+                Log.e(tag, "✗ Service registration FAILED")
+                Log.e(tag, "  - Error code: $errorCode")
+                Log.e(tag, "  - Service name: ${serviceInfo.serviceName}")
+                Log.e(tag, "  - Service type: ${serviceInfo.serviceType}")
+                when (errorCode) {
+                    NsdManager.FAILURE_ALREADY_ACTIVE -> Log.e(tag, "  - Reason: Service already registered")
+                    NsdManager.FAILURE_INTERNAL_ERROR -> Log.e(tag, "  - Reason: Internal NSD error")
+                    NsdManager.FAILURE_MAX_LIMIT -> Log.e(tag, "  - Reason: Maximum outstanding requests reached")
+                    else -> Log.e(tag, "  - Reason: Unknown error")
+                }
             }
 
             override fun onUnregistrationFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
@@ -436,7 +454,16 @@ class NetworkManager(private val context: Context) {
             }
 
             override fun onServiceRegistered(serviceInfo: NsdServiceInfo) {
-                Log.d(tag, "✓ Service REGISTERED successfully: ${serviceInfo.serviceName}")
+                Log.d(tag, "")
+                Log.d(tag, "╔════════════════════════════════════════╗")
+                Log.d(tag, "║  ✓ NSD SERVICE REGISTERED             ║")
+                Log.d(tag, "╠════════════════════════════════════════╣")
+                Log.d(tag, "║  Name: ${serviceInfo.serviceName.padEnd(29)}║")
+                Log.d(tag, "║  Type: ${serviceInfo.serviceType.padEnd(29)}║")
+                Log.d(tag, "║  Port: ${port.toString().padEnd(29)}║")
+                Log.d(tag, "╚════════════════════════════════════════╝")
+                Log.d(tag, "")
+                Log.d(tag, "Host is now discoverable on the local network!")
             }
 
             override fun onServiceUnregistered(serviceInfo: NsdServiceInfo) {
@@ -527,6 +554,78 @@ class NetworkManager(private val context: Context) {
     }
 
     /**
+     * Check WiFi connectivity and log network information
+     */
+    private fun checkWiFiConnectivity() {
+        try {
+            // Check if running on emulator
+            val isEmulator = Build.FINGERPRINT.contains("generic") ||
+                    Build.FINGERPRINT.startsWith("unknown") ||
+                    Build.MODEL.contains("google_sdk") ||
+                    Build.MODEL.contains("Emulator") ||
+                    Build.MODEL.contains("Android SDK") ||
+                    Build.MANUFACTURER.contains("Genymotion") ||
+                    Build.PRODUCT.contains("sdk_gphone") ||
+                    Build.PRODUCT.contains("sdk") ||
+                    Build.PRODUCT.contains("sdk_x86") ||
+                    Build.PRODUCT.contains("vbox86p") ||
+                    Build.PRODUCT.contains("emulator") ||
+                    Build.HARDWARE.contains("goldfish") ||
+                    Build.HARDWARE.contains("ranchu")
+
+            val wifiManager = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+            val isWifiEnabled = wifiManager.isWifiEnabled
+
+            Log.d(tag, "=== Network Diagnostics ===")
+            Log.d(tag, "Device: ${Build.MANUFACTURER} ${Build.MODEL}")
+            Log.d(tag, "Running on emulator: $isEmulator")
+
+            if (isEmulator) {
+                Log.w(tag, "")
+                Log.w(tag, "⚠️  WARNING: Android Emulator Detected!")
+                Log.w(tag, "   NSD (Network Service Discovery) does NOT work in the Android Emulator.")
+                Log.w(tag, "   Please test on physical devices connected to the same WiFi network.")
+                Log.w(tag, "")
+            }
+
+            Log.d(tag, "WiFi Enabled: $isWifiEnabled")
+
+            if (isWifiEnabled) {
+                val wifiInfo = wifiManager.connectionInfo
+                Log.d(tag, "SSID: ${wifiInfo.ssid}")
+                Log.d(tag, "IP Address: ${formatIpAddress(wifiInfo.ipAddress)}")
+                Log.d(tag, "Link Speed: ${wifiInfo.linkSpeed} Mbps")
+                Log.d(tag, "RSSI: ${wifiInfo.rssi}")
+
+                // Get DHCP Info
+                val dhcpInfo = wifiManager.dhcpInfo
+                Log.d(tag, "Gateway: ${formatIpAddress(dhcpInfo.gateway)}")
+                Log.d(tag, "Netmask: ${formatIpAddress(dhcpInfo.netmask)}")
+                Log.d(tag, "DNS1: ${formatIpAddress(dhcpInfo.dns1)}")
+            } else {
+                Log.e(tag, "✗ WiFi is DISABLED! NSD requires WiFi to be enabled.")
+            }
+
+            Log.d(tag, "=========================")
+        } catch (e: Exception) {
+            Log.e(tag, "Error checking WiFi connectivity", e)
+        }
+    }
+
+    /**
+     * Format IP address from integer to string
+     */
+    private fun formatIpAddress(ip: Int): String {
+        return String.format(
+            "%d.%d.%d.%d",
+            ip and 0xff,
+            (ip shr 8) and 0xff,
+            (ip shr 16) and 0xff,
+            (ip shr 24) and 0xff
+        )
+    }
+
+    /**
      * Acquire WiFi multicast lock for NSD to work
      */
     private fun acquireMulticastLock() {
@@ -537,10 +636,13 @@ class NetworkManager(private val context: Context) {
                     setReferenceCounted(true)
                     acquire()
                 }
-                Log.d(tag, "✓ Multicast lock acquired")
+                Log.d(tag, "✓ Multicast lock acquired successfully")
+                Log.d(tag, "  - Lock is held: ${multicastLock?.isHeld}")
             } catch (e: Exception) {
                 Log.e(tag, "✗ Failed to acquire multicast lock", e)
             }
+        } else {
+            Log.d(tag, "ℹ Multicast lock already held")
         }
     }
 


### PR DESCRIPTION
This commit adds extensive debugging capabilities to help diagnose why players cannot discover each other on the same WLAN network:

Enhanced Diagnostics:
- WiFi connectivity check with detailed network information
- Device information logging (SSID, IP, gateway, etc.)
- Emulator detection with warning message
- Multicast lock acquisition verification
- Enhanced NSD registration error messages with error code descriptions

Network Information Logged:
- WiFi enabled status
- SSID of connected network
- IP address, gateway, netmask, DNS
- Link speed and signal strength (RSSI)
- Multicast lock status

Critical Warning Added:
- Detects Android Emulator and warns that NSD does NOT work in emulators
- Only physical devices on the same WiFi network can discover each other

This should help identify common issues:
1. WiFi disabled or not connected
2. Running on emulator (NSD not supported)
3. Multicast lock not acquired
4. NSD registration failures with specific error codes

Test on real devices for actual network discovery functionality.