### PR TITLE
Implement hybrid game over rule with adaptive spawn positioning

### DIFF
--- a/app/src/main/java/com/tetris/game/TetrisGame.kt
+++ b/app/src/main/java/com/tetris/game/TetrisGame.kt
@@ -262,12 +262,58 @@ class TetrisGame(
     }
 
     private fun spawnNextPiece() {
-        _currentPiece.value = _nextPiece.value
+        val piece = _nextPiece.value ?: return
         _nextPiece.value = spawnPiece()
+
+        // Try to spawn at y=0, if collision move up (y=-1, -2, etc.)
+        var spawnY = 0
+        val maxAttempts = 5 // Try up to y=-4
+
+        while (spawnY >= -maxAttempts) {
+            val positionedPiece = piece.copy(y = spawnY)
+            if (!board.checkCollision(positionedPiece)) {
+                // Found valid spawn position
+                _currentPiece.value = positionedPiece
+                return
+            }
+            spawnY--
+        }
+
+        // Could not spawn even at y=-5, game over
+        val stats = _stats.value
+        _gameState.value = GameState.GameOver(
+            score = stats.score,
+            level = stats.level,
+            lines = stats.linesCleared
+        )
+        gameLoopJob?.cancel()
     }
 
     private fun spawnSavedPiece(piece: Tetromino?) {
-        _currentPiece.value = piece
+        if (piece == null) return
+
+        // Try to spawn at y=0, if collision move up (y=-1, -2, etc.)
+        var spawnY = 0
+        val maxAttempts = 5 // Try up to y=-4
+
+        while (spawnY >= -maxAttempts) {
+            val positionedPiece = piece.copy(y = spawnY)
+            if (!board.checkCollision(positionedPiece)) {
+                // Found valid spawn position
+                _currentPiece.value = positionedPiece
+                return
+            }
+            spawnY--
+        }
+
+        // Could not spawn even at y=-5, game over
+        val stats = _stats.value
+        _gameState.value = GameState.GameOver(
+            score = stats.score,
+            level = stats.level,
+            lines = stats.linesCleared
+        )
+        gameLoopJob?.cancel()
     }
 
     private fun checkGameOver(piece: Tetromino): Boolean {


### PR DESCRIPTION
Fixed game over detection to properly trigger using a hybrid approach that combines spawn collision checking with lock-out detection.

Game Over Rules (Hybrid):
1. Spawn-time check: Try to spawn at y=0 (visible)
   - If collision: Try y=-1, -2, -3, -4, -5
   - If still collision at y=-5: Immediate game over (board too full)

2. Lock-time check: When piece locks
   - If piece has blocks at y < 0: Game over (lock-out)

How it works:
- Pieces prefer to spawn at y=0 (visible) for normal gameplay
- If top row is full, pieces spawn higher (y=-1, etc.) to allow play
- Game continues as long as pieces can find valid spawn position
- Game over triggers when: a) Board so full that piece can't spawn even at y=-5, OR b) Piece locks while still having blocks above visible area (y < 0)

Implementation:
- spawnNextPiece() / spawnSavedPiece():
  * Try spawn positions from y=0 down to y=-5
  * Find first position without collision
  * If no valid position found → immediate game over

- checkGameOver() in lockPiece():
  * Checks if locked piece has blocks at y < 0
  * If yes → game over (lock-out rule)

This allows the game to continue even with partially filled top rows, while still properly ending the game when the player truly cannot continue.