### PR TITLE
Fix next piece changing unexpectedly after spawn

### DIFF
--- a/app/src/main/java/com/tetris/game/TetrisGame.kt
+++ b/app/src/main/java/com/tetris/game/TetrisGame.kt
@@ -49,10 +49,14 @@ class TetrisGame(
         board.reset()
         _stats.value = GameStats()
         _currentPiece.value = null
+
+        // Generate first two pieces
+        val firstPiece = spawnPiece()
         _nextPiece.value = spawnPiece()
         _gameState.value = GameState.Playing
 
-        spawnNextPiece()
+        // Spawn first piece
+        spawnInitialPiece(firstPiece)
         startGameLoop()
     }
 
@@ -261,25 +265,21 @@ class TetrisGame(
         return tetromino.copy(x = startX, y = 0)
     }
 
-    private fun spawnNextPiece() {
-        val piece = _nextPiece.value ?: return
-        _nextPiece.value = spawnPiece()
-
-        // Try to spawn at y=0, if collision move up (y=-1, -2, etc.)
+    private fun spawnInitialPiece(piece: Tetromino) {
+        // Initial spawn for game start - try y=0, move up if needed
         var spawnY = 0
-        val maxAttempts = 5 // Try up to y=-4
+        val maxAttempts = 5
 
         while (spawnY >= -maxAttempts) {
             val positionedPiece = piece.copy(y = spawnY)
             if (!board.checkCollision(positionedPiece)) {
-                // Found valid spawn position
                 _currentPiece.value = positionedPiece
                 return
             }
             spawnY--
         }
 
-        // Could not spawn even at y=-5, game over
+        // Could not spawn, immediate game over
         val stats = _stats.value
         _gameState.value = GameState.GameOver(
             score = stats.score,
@@ -294,7 +294,7 @@ class TetrisGame(
 
         // Try to spawn at y=0, if collision move up (y=-1, -2, etc.)
         var spawnY = 0
-        val maxAttempts = 5 // Try up to y=-4
+        val maxAttempts = 5
 
         while (spawnY >= -maxAttempts) {
             val positionedPiece = piece.copy(y = spawnY)


### PR DESCRIPTION
Fixed issue where next piece would change twice: once when piece locks, and again when new piece spawns, causing the displayed next piece to flicker or change while current piece is falling.

Root cause: Next piece was being generated in two places:
1. In lockPiece() - when current piece locks
2. In spawnNextPiece() - when spawning the saved piece

This caused the next piece to change twice in quick succession, making it appear to change while the current piece was already falling.

Solution: Restructured piece spawning logic:
- startGame(): Generate TWO pieces upfront
  * First piece → spawn as current
  * Second piece → set as next
  * No flickering at game start

- lockPiece(): Generate new next piece (ONLY place during gameplay)
  * Save current next as pieceToSpawn
  * Generate new next immediately
  * Spawn pieceToSpawn after animation

- spawnSavedPiece(): Spawn saved piece WITHOUT generating new next
  * Only updates current piece
  * Next piece remains stable

- New spawnInitialPiece(): Initial spawn helper for game start

Now the next piece changes only ONCE per piece lock, at the exact moment when the old next becomes current. The displayed next piece remains stable while current piece is falling.